### PR TITLE
Bug 1120471: Add timer support

### DIFF
--- a/include/fdio/timer.h
+++ b/include/fdio/timer.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2015  Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+/*
+ * This is a simple timer API for libfdio.
+ *
+ * Call |add_relative_timer_to_epoll_loop| to install a timer that fires
+ * relative to the current time. The return value is either the timer's
+ * file descriptor, or -1 in the case of an error.
+ *
+ * The parameter |clockid| is the system clock for the timer, as given
+ * in 'man timerfd_create'. The parameter |timeout_ms| sets the timeout
+ * of the timer; relative to the current time. The parameter |interval_ms|
+ * sets the timer's interval _after_ the timer first fired. If the
+ * interval is 0, the timer will fire just once. Both time values are
+ * specified in milliseconds. The parameters |func| and |data| set the
+ * call-back function and user data. All timers will fire from within
+ * the I/O thread.
+ *
+ * The function |add_absolute_timer_to_epoll_loop| adds an absolute timer
+ * to the I/O loop. The parameter |timeout_ms| specifies a timeout at
+ * an absolute time. All other parameters are the same as for
+ * |add_relative_timer_to_epoll_loop|.
+ *
+ * To remove an existing timer, call |remove_timer|. The parameter is
+ * a timer that has been returned by |add_timer_to_epoll_loop|. The
+ * function will remove the timer from the I/O loop and cleanup its
+ * resources.
+ */
+
+#include <stdint.h>
+#include "ioresult.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int
+add_relative_timer_to_epoll_loop(int clockid,
+                                 unsigned long long timeout_ms,
+                                 unsigned long long interval_ms,
+                                 enum ioresult (*func)(int, uint32_t, void*),
+                                 void* data);
+
+int
+add_absolute_timer_to_epoll_loop(int clockid,
+                                 unsigned long long timeout_ms,
+                                 unsigned long long interval_ms,
+                                 enum ioresult (*func)(int, uint32_t, void*),
+                                 void* data);
+
+void
+remove_timer(int timer);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/Android.mk
+++ b/src/Android.mk
@@ -1,9 +1,17 @@
 LOCAL_PATH:= $(call my-dir)
 
+local_source_files_14 := ports/timerfd.c
+local_source_files_15 := $(local_source_files_14)
+local_source_files_16 := $(local_source_files_15)
+local_source_files_17 := $(local_source_files_16)
+local_source_files_18 := $(local_source_files_17)
+local_source_files    := $(local_source_files_$(PLATFORM_SDK_VERSION))
+
 include $(CLEAR_VARS)
-LOCAL_SRC_FILES:= fdstate.c \
-                  loop.c \
-                  task.c
+LOCAL_SRC_FILES := fdstate.c \
+                   loop.c \
+                   task.c \
+                   $(local_source_files)
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/../include
 LOCAL_CFLAGS := -DANDROID_VERSION=$(PLATFORM_SDK_VERSION) -Wall -Werror
 LOCAL_SHARED_LIBRARIES := libcutils liblog

--- a/src/Android.mk
+++ b/src/Android.mk
@@ -11,6 +11,7 @@ include $(CLEAR_VARS)
 LOCAL_SRC_FILES := fdstate.c \
                    loop.c \
                    task.c \
+                   timer.c \
                    $(local_source_files)
 LOCAL_C_INCLUDES := $(LOCAL_PATH)/../include
 LOCAL_CFLAGS := -DANDROID_VERSION=$(PLATFORM_SDK_VERSION) -Wall -Werror

--- a/src/ports/sys/timerfd.h
+++ b/src/ports/sys/timerfd.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2015  Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#if ANDROID_VERSION >= 19
+
+#include <sys/timerfd.h>
+
+#else
+
+/*
+ * See 'man 2 timerfd_create' for documentation of these functions.
+ */
+
+#include <time.h>
+#include <fcntl.h>
+#include <sys/types.h>
+
+/* defined by kernel in <include/linux/timerfd.h> */
+#define TFD_TIMER_ABSTIME (1 << 0)
+#define TFD_TIMER_CANCEL_ON_SET (1 << 1)
+#define TFD_CLOEXEC O_CLOEXEC
+#define TFD_NONBLOCK O_NONBLOCK
+
+int
+timerfd_create(int clockid, int flags);
+
+int
+timerfd_settime(int fd, int flags,
+                const struct itimerspec* new_value,
+                struct itimerspec* old_value);
+
+int
+timerfd_gettime(int fd, struct itimerspec* curr_value);
+
+#endif

--- a/src/ports/timerfd.c
+++ b/src/ports/timerfd.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015  Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <sys/syscall.h>
+#include "sys/timerfd.h"
+
+/* The C library's implementation of the timerfd API just moves
+ * the arguments into the right places and triggers the system
+ * call. We can do the same by using the syscall function. The
+ * __NR_ constants are available on all platforms.
+ */
+
+int
+timerfd_create(int clockid, int flags)
+{
+  return syscall(__NR_timerfd_create, clockid, flags, 0, 0, 0, 0);
+}
+
+int
+timerfd_settime(int fd, int flags,
+                const struct itimerspec* new_value,
+                struct itimerspec* old_value)
+{
+  return syscall(__NR_timerfd_settime, fd, flags, new_value, old_value, 0, 0);
+}
+
+int
+timerfd_gettime(int fd, struct itimerspec* curr_value)
+{
+  return syscall(__NR_timerfd_gettime, fd, curr_value);
+}

--- a/src/timer.c
+++ b/src/timer.c
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2015  Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <ports/sys/timerfd.h>
+#include <sys/epoll.h>
+#include <fdio/loop.h>
+#include <fdio/task.h>
+#include <fdio/timer.h>
+#include "log.h"
+
+struct timer_param {
+  enum ioresult (*func)(int, uint32_t, void*);
+  void* data;
+};
+
+struct add_timer_param {
+  int fd;
+  struct timer_param param;
+};
+
+static enum ioresult
+add_timer_cb(void* data)
+{
+  struct add_timer_param* param = data;
+  assert(param);
+
+  add_fd_to_epoll_loop(param->fd, EPOLLIN | EPOLLERR,
+                       param->param.func, param->param.data);
+  free(param);
+
+  return IO_OK;
+}
+
+static enum ioresult
+remove_timer_cb(void* data)
+{
+  int fd = (int)data;
+
+  remove_fd_from_epoll_loop(fd);
+
+  return IO_OK;
+}
+
+static struct timespec*
+set_timespec(struct timespec* timespec,
+             unsigned long long time_ms)
+{
+  static const unsigned long long MS_PER_S = 1000;
+  static const unsigned long long NS_PER_MS = 1000000;
+
+  timespec->tv_sec = time_ms / MS_PER_S;
+  timespec->tv_nsec = (time_ms % MS_PER_S) * NS_PER_MS;
+
+  return timespec;
+}
+
+static int
+add_timer(int clockid,
+          int timeout_is_absolute,
+          unsigned long long timeout_ms,
+          unsigned long long interval_ms,
+          enum ioresult (*func)(int, uint32_t, void*),
+          void* data)
+{
+  int fd, flags;
+  struct itimerspec timeout;
+  struct add_timer_param* param;
+
+  assert(timeout_ms);
+
+  fd = timerfd_create(clockid, TFD_NONBLOCK | TFD_CLOEXEC);
+  if (fd < 0) {
+    ALOGE_ERRNO("timerfd_create");
+    return -1;
+  }
+
+  flags = 0;
+
+  if (timeout_is_absolute)
+    flags |= TFD_TIMER_ABSTIME;
+
+  set_timespec(&timeout.it_value, timeout_ms);
+  set_timespec(&timeout.it_interval, interval_ms);
+
+  if (timerfd_settime(fd, flags, &timeout, NULL) < 0) {
+    ALOGE_ERRNO("timerfd_settime");
+    goto err_timerfd_settime;
+  }
+
+  /* install timerfd from within I/O loop */
+
+  errno = 0;
+  param = malloc(sizeof(*param));
+  if (errno) {
+    ALOGE_ERRNO("malloc");
+    goto err_malloc;
+  }
+
+  param->fd = fd;
+  param->param.func = func;
+  param->param.data = data;
+
+  if (run_task(add_timer_cb, param) < 0)
+    goto err_run_task;
+
+  return fd;
+
+err_run_task:
+  free(param);
+err_malloc:
+err_timerfd_settime:
+  if (TEMP_FAILURE_RETRY(close(fd)) < 0)
+    ALOGW_ERRNO("close");
+  return -1;
+}
+
+int
+add_relative_timer_to_epoll_loop(int clockid,
+                                 unsigned long long timeout_ms,
+                                 unsigned long long interval_ms,
+                                 enum ioresult (*func)(int, uint32_t, void*),
+                                 void* data)
+{
+  assert(interval_ms);
+
+  return add_timer(clockid, 0, timeout_ms, interval_ms, func, data);
+}
+
+int
+add_absolute_timer_to_epoll_loop(int clockid,
+                                 unsigned long long timeout_ms,
+                                 unsigned long long interval_ms,
+                                 enum ioresult (*func)(int, uint32_t, void*),
+                                 void* data)
+{
+  assert(timeout_ms);
+
+  return add_timer(clockid, 1, timeout_ms, interval_ms, func, data);
+}
+
+void
+remove_timer(int timer)
+{
+  if (run_task(remove_timer_cb, (void*)timer) < 0)
+    goto err_run_task;
+
+  return;
+
+err_run_task:
+  /* If anything goes wrong, we cleanup here and hope for the best.
+   */
+  remove_fd_from_epoll_loop(timer);
+  if (TEMP_FAILURE_RETRY(close(timer)) < 0)
+    ALOGW_ERRNO("close");
+  return;
+}


### PR DESCRIPTION
libfdio now provides timer support. For each timer, callers can
specify a call-back function and user data. Timers can be periodic
or single-shot only, starting at an absolute or relative time.

Thanks to Bruce Sun, who pointed out a bug in the handling of
periodic timers.