### PR TITLE
Bug 1131658: Test malloc's success by returned value instead of errno

### DIFF
--- a/src/fdstate.c
+++ b/src/fdstate.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014  Mozilla Foundation
+ * Copyright (C) 2014-2015  Mozilla Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,9 +63,8 @@ get_fd_state(int fd, int alloc)
     return NULL;
   }
 
-  errno = 0;
   mem = realloc(fd_state, newnfdstates * sizeof(*fd_state));
-  if (errno) {
+  if (!mem) {
     ALOGE_ERRNO("realloc");
     return NULL;
   }

--- a/src/task.c
+++ b/src/task.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014  Mozilla Foundation
+ * Copyright (C) 2014-2015  Mozilla Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -155,9 +155,8 @@ create_task(enum ioresult (*func)(void*), void* data)
 
   assert(func);
 
-  errno = 0;
   task = malloc(sizeof(*task));
-  if (errno) {
+  if (!task) {
     ALOGE_ERRNO("malloc");
     return NULL;
   }


### PR DESCRIPTION
We found an implementation of |malloc| that sets errno even if the
allocation succeeded. The current error checks return false positives
in this case.

This patch changes the code to test the returned pointer for a non-null
value instead.